### PR TITLE
Add overload to log without a job id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,13 @@ App_Data/
 bin/
 obj/
 
+# NuGet Packages
+*.nupkg
+# The packages folddder can be ignored because of Package Restore
+**/packages/*
+packages/
+# except build/, which is used as an MSBuild target.
+!**/packages/build/
 
 # Files
 #######################

--- a/hangfire.job.logging/JobContext.cs
+++ b/hangfire.job.logging/JobContext.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Hangfire.Server;
+
+namespace hangfire.job.logging
+{
+    public class JobContext : IServerFilter
+    {
+        [ThreadStatic]
+        private static string _jobId;
+
+        public static string JobId => _jobId;
+
+        public void OnPerforming(PerformingContext filterContext)
+        {
+            _jobId = filterContext.BackgroundJob.Id;
+        }
+
+        public void OnPerformed(PerformedContext filterContext)
+        {
+            _jobId = "";
+        }
+    }
+}

--- a/hangfire.job.logging/JobLogger.cs
+++ b/hangfire.job.logging/JobLogger.cs
@@ -19,6 +19,20 @@ namespace hangfire.job.logging
             ExecuteCommand(command);
         }
 
+        public void Write(string message)
+        {
+            var jobId = JobContext.JobId;
+
+            if (string.IsNullOrEmpty(jobId))
+            {
+                return;
+            }
+
+            var command = BuildCommand(jobId, message);
+
+            ExecuteCommand(command);
+        }
+
         private void ExecuteCommand(SqlCommand command)
         {
             using (var connection = new SqlConnection(connectionString))

--- a/hangfire.job.logging/packages.config
+++ b/hangfire.job.logging/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Hangfire" version="1.6.4" targetFramework="net45" />
+  <package id="Hangfire.Core" version="1.6.4" targetFramework="net45" />
+  <package id="Hangfire.SqlServer" version="1.6.4" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="3.0.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net45" />
+  <package id="Owin" version="1.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
This fixes #1 by adding the Hangfire package
and creating a job filter to expose the
current job id. The ID is unset when the job
is completed to avoid problems that might
occur when the thread pool reuses a thread,
since it does not clear existing static fields.
